### PR TITLE
Fix #3 and Add CRAN repo to `run-logolink.yaml`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 *.nlogox linguist-detectable
 *.nlogox3d linguist-detectable
 *.qmd linguist-detectable
+*.yaml linguist-detectable
 
 *.nls linguist-language=NetLogo
 *.nlogo linguist-language=NetLogo
@@ -11,9 +12,11 @@
 *.nlogox linguist-language=NetLogo
 *.nlogox3d linguist-language=NetLogo
 *.qmd linguist-language=R
-*.yaml linguist-language=bash
+*.yaml linguist-language=Shell
 
 images/* linguist-documentation
 docs/* linguist-documentation
+tests/* linguist-documentation
 
 extensions/* linguist-vendored
+models/* linguist-vendored

--- a/.github/workflows/run-logolink.yaml
+++ b/.github/workflows/run-logolink.yaml
@@ -77,6 +77,8 @@ jobs:
         run: |
           # Install and initialize renv
 
+          options(repos=c(CRAN="https://cloud.r-project.org"))
+
           install.packages("renv")
 
           renv::init()

--- a/.github/workflows/test-setup-netlogo.yaml
+++ b/.github/workflows/test-setup-netlogo.yaml
@@ -1,6 +1,5 @@
 on:
   push:
-    branches: [main, master]
 
 name: "setup-netlogo" # Do not change!
 permissions: read-all
@@ -11,11 +10,11 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: windows-latest, version: '6.4.0'}
-          - {os: windows-latest, version: 'release'}
+          # - {os: windows-latest, version: '6.4.0'}
+          # - {os: windows-latest, version: 'release'}
           - {os: macos-latest, version: 'release'}
-          - {os: ubuntu-latest, version: '6.4.0'}
-          - {os: ubuntu-latest, version: 'release'}
+          # - {os: ubuntu-latest, version: '6.4.0'}
+          # - {os: ubuntu-latest, version: 'release'}
         cache: ['false', 'true']
     name: "${{ matrix.config.os }} (version: '${{ matrix.config.version }}') (cache: '${{ matrix.cache }}')"
     runs-on: ${{ matrix.config.os }}

--- a/.github/workflows/test-setup-netlogo.yaml
+++ b/.github/workflows/test-setup-netlogo.yaml
@@ -1,5 +1,6 @@
 on:
   push:
+    branches: [main, master]
 
 name: "setup-netlogo" # Do not change!
 permissions: read-all
@@ -10,11 +11,11 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          # - {os: windows-latest, version: '6.4.0'}
-          # - {os: windows-latest, version: 'release'}
+          - {os: windows-latest, version: '6.4.0'}
+          - {os: windows-latest, version: 'release'}
           - {os: macos-latest, version: 'release'}
-          # - {os: ubuntu-latest, version: '6.4.0'}
-          # - {os: ubuntu-latest, version: 'release'}
+          - {os: ubuntu-latest, version: '6.4.0'}
+          - {os: ubuntu-latest, version: 'release'}
         cache: ['false', 'true']
     name: "${{ matrix.config.os }} (version: '${{ matrix.config.version }}') (cache: '${{ matrix.cache }}')"
     runs-on: ${{ matrix.config.os }}

--- a/README.md
+++ b/README.md
@@ -213,6 +213,8 @@ jobs:
         run: |
           # Install and initialize renv
 
+          options(repos=c(CRAN="https://cloud.r-project.org"))
+
           install.packages("renv")
 
           renv::init()
@@ -399,7 +401,7 @@ donation. Please mention `LogoActions` in your donation message.
 [![License: GPLv3](https://img.shields.io/badge/license-GPLv3-bd0000.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
 ```text
-Copyright (C) 2025 Daniel Vartanian
+Copyright (C) 2026 Daniel Vartanian
 
 LogoActions is free software: you can redistribute it and/or modify it
 under the terms of the GNU General Public License as published by the Free

--- a/setup-netlogo/action.yaml
+++ b/setup-netlogo/action.yaml
@@ -34,7 +34,7 @@ runs:
           echo \
             "Error: Invalid version format" \
             "('${{ inputs.version }}')." \
-            "Use semantic versioning (e.g., '7.0.2') or use" \
+            "Use semantic versioning (e.g., '7.0.4') or use" \
             "'release' to get the latest stable release."
 
           exit 1
@@ -397,7 +397,7 @@ runs:
             sudo ln -sf "${netlogo_binary}" "/usr/local/bin/netlogo"
             ;;
           "macOS")
-            netlogo_binary="${NETLOGO_HOME}/NetLogo 7.0.3.app/Contents/MacOS/NetLogo 7.0.3"
+            netlogo_binary="${NETLOGO_HOME}/NetLogo ${NETLOGO_VERSION}.app/Contents/MacOS/NetLogo ${NETLOGO_VERSION}"
 
             sudo ln -sf "${netlogo_binary}" "/usr/local/bin/NetLogo"
             sudo ln -sf "${netlogo_binary}" "/usr/local/bin/netlogo"

--- a/setup-netlogo/action.yaml
+++ b/setup-netlogo/action.yaml
@@ -114,7 +114,7 @@ runs:
             cache_path="/opt/NetLogo ${NETLOGO_VERSION}"
             ;;
           "macOS")
-            cache_path="/Applications/NetLogo ${NETLOGO_VERSION}.app"
+            cache_path="/Applications/NetLogo ${NETLOGO_VERSION}"
             ;;
           "Windows")
             case ${RUNNER_ARCH} in


### PR DESCRIPTION
See #3.

## Resolution

The symlink was pointing to `NetLogo 7.0.3.app/…` regardless of the installed version, so on 7.0.4 the target didn't exist and `netlogo` resolved to a broken link.

https://github.com/danielvartan/logoactions/blob/b1e159cf57ac0646e0c9ec79fb88815899d6461f/setup-netlogo/action.yaml#L400